### PR TITLE
Fix WiFi-Display on Huawei devices (EMUI 8.0)

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -4244,9 +4244,8 @@ status_t ACodec::setupAVCEncoderParameters(const sp<AMessage> &msg) {
     if (msg->findInt32("intra-refresh-mode", &intraRefreshMode)) {
         err = setCyclicIntraMacroblockRefresh(msg, intraRefreshMode);
         if (err != OK) {
-            ALOGE("Setting intra macroblock refresh mode (%d) failed: 0x%x",
-                    err, intraRefreshMode);
-            return err;
+            ALOGE("setupAVCEncoderParameters(): set intra-refresh-mode failed, ignoring..");
+            //return err;
         }
     }
 


### PR DESCRIPTION
Huaweis media stack doesn't handle intra-refresh-mode, so skip the error instead.

Thanks to Chris Vandomelen for pointing that out.