### PR TITLE
Fix null pointer for unknown audio sources in "Fix BT in-call on CAF devices

### DIFF
--- a/services/audiopolicy/common/managerdefinitions/src/Serializer.cpp
+++ b/services/audiopolicy/common/managerdefinitions/src/Serializer.cpp
@@ -685,8 +685,10 @@ static void fixupQualcommBtScoRoute(RouteTraits::Collection& routes, DevicePortT
             }) {
         auto source = ctx->findPortByTagName(String8(sourceName));
         ALOGE("Got source %p\n", source.get());
-        sources.add(source);
-	source->addRoute(newRoute);
+	if (source.get() != nullptr) {
+	    sources.add(source);
+	    source->addRoute(newRoute);
+	}
     }
 
     newRoute->setSources(sources);


### PR DESCRIPTION


Some audio sources may not exist on some devices (e.g. Axon 7), leading to a segmentation fault.