### PR TITLE
audiopolicy: try again with trimmed audio port name if not found

### DIFF
--- a/services/audiopolicy/common/managerdefinitions/src/Serializer.cpp
+++ b/services/audiopolicy/common/managerdefinitions/src/Serializer.cpp
@@ -550,6 +550,17 @@ Return<DevicePortTraits::Element> DevicePortTraits::deserialize(const xmlNode *c
     return deviceDesc;
 }
 
+char* trim(char * s) {
+    int l = strlen(s);
+
+    if (l > 0) {
+      while (isspace(s[l - 1])) --l;
+      while (*s && isspace(*s)) ++s, --l;
+    }
+
+    return strndup(s, l);
+}
+
 Return<RouteTraits::Element> RouteTraits::deserialize(const xmlNode *cur, PtrSerializingCtx ctx)
 {
     std::string type = getXmlAttribute(cur, Attributes::type);
@@ -590,8 +601,11 @@ Return<RouteTraits::Element> RouteTraits::deserialize(const xmlNode *cur, PtrSer
         if (strlen(devTag) != 0) {
             sp<AudioPort> source = ctx->findPortByTagName(String8(devTag));
             if (source == NULL) {
-                ALOGE("%s: no source found with name=%s", __func__, devTag);
-                return Status::fromStatusT(BAD_VALUE);
+                source = ctx->findPortByTagName(String8(trim(devTag)));
+                if (source == NULL) {
+                    ALOGE("%s: no source found with name=%s", __func__, devTag);
+                    return Status::fromStatusT(BAD_VALUE);
+                }
             }
             sources.add(source);
         }


### PR DESCRIPTION
* In Spreadtrum BSP, some audio routes may contain ports with extra
  spaces at the beginning and the end, causing audiopolicy to refuse to
  load and leading to broken audio.

* Fix this by retrying with trimmed port name when not found. Do not
  use trimmed name all the time because a white space is a valid
  character in port name, and we cannot be sure nobody is using it for
  legitimite purposes.