### PR TITLE
 APM: Fall back to legacy voice call routing if creating audio patch failed

### DIFF
--- a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
@@ -3490,8 +3490,7 @@ status_t AudioPolicyManager::getAudioPort(struct audio_port *port)
 status_t AudioPolicyManager::createAudioPatchInternal(const struct audio_patch *patch,
                                                       audio_patch_handle_t *handle,
                                                       uid_t uid, uint32_t delayMs,
-                                                      const sp<SourceClientDescriptor>& sourceDesc,
-                                                      bool forceSwBridge)
+                                                      const sp<SourceClientDescriptor>& sourceDesc)
 {
     ALOGV("%s", __func__);
     if (handle == NULL || patch == NULL) {
@@ -3695,8 +3694,7 @@ status_t AudioPolicyManager::createAudioPatchInternal(const struct audio_patch *
                 // - audio HAL version is >= 3.0 but no route has been declared between devices
                 // - called from startAudioSource (aka sourceDesc != nullptr) and source device does
                 //   not have a gain controller
-                // - a previous attempt at using HW bridge failed (forceSwBridge)
-                if (forceSwBridge || !srcDevice->hasSameHwModuleAs(sinkDevice) ||
+                if (!srcDevice->hasSameHwModuleAs(sinkDevice) ||
                         (srcDevice->getModuleVersionMajor() < 3) ||
                         !srcDevice->getModule()->supportsPatch(srcDevice, sinkDevice) ||
                         (sourceDesc != nullptr &&
@@ -3761,12 +3759,7 @@ status_t AudioPolicyManager::createAudioPatchInternal(const struct audio_patch *
                         __func__, index, handle, patchBuilder.patch(), delayMs, uid, &patchDesc);
             if (status != NO_ERROR) {
                 ALOGW("%s patch panel could not connect device patch, error %d", __func__, status);
-                if (forceSwBridge || patch->sinks[0].type != AUDIO_PORT_TYPE_DEVICE) {
-                    return INVALID_OPERATION;
-                } else {
-                    ALOGW("Retrying with software bridging.");
-                    return createAudioPatchInternal(patch, handle, uid, delayMs, sourceDesc, true);
-                }
+                return INVALID_OPERATION;
             }
         } else {
             return BAD_VALUE;

--- a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
@@ -575,16 +575,29 @@ uint32_t AudioPolicyManager::updateCallRouting(const DeviceVector &rxDevices, ui
         createTxPatch = !(availablePrimaryModuleInputDevices().contains(txSourceDevice)) &&
                 (txSinkDevice != 0);
     }
-    // Use legacy routing method for voice calls via setOutputDevice() on primary output.
-    // Otherwise, create two audio patches for TX and RX path.
-    if (!createRxPatch) {
-        muteWaitMs = setOutputDevices(mPrimaryOutput, rxDevices, true, delayMs);
-    } else { // create RX path audio patch
+    if (createRxPatch) { // create RX path audio patch
         mCallRxPatch = createTelephonyPatch(true /*isRx*/, rxDevices.itemAt(0), delayMs);
+
+        if (mCallRxPatch == nullptr) {
+            // Fall back to legacy routing for voice calls if the new patching method
+            // failed. setOutputDevice() will take care of TX in this case, so don't
+            // create the TX patch either.
+            // This is seen on some MT6771 devices on Q vendor, where the HAL claims
+            // support for HW patch between telephony inputs and outputs, but fails
+            // to create one when called with the createAudioPatch() method. SW audio
+            // bridges are also broken on them due to improperly configured audio policy.
+            ALOGW("Failed to create RX path audio patch, falling back to pre-R behavior");
+            createRxPatch = false;
+            createTxPatch = false;
+        }
 
         // If the TX device is on the primary HW module but RX device is
         // on other HW module, SinkMetaData of telephony input should handle it
         // assuming the device uses audio HAL V5.0 and above
+    }
+    // Use legacy routing method for voice calls via setOutputDevice() on primary output.
+    if (!createRxPatch) {
+        muteWaitMs = setOutputDevices(mPrimaryOutput, rxDevices, true, delayMs);
     }
     if (createTxPatch) { // create TX path audio patch
         // terminate active capture if on the same HW module as the call TX source device

--- a/services/audiopolicy/managerdefault/AudioPolicyManager.h
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.h
@@ -910,14 +910,12 @@ private:
          * @param[in] delayMs if required
          * @param[in] sourceDesc [optional] in case of external source, source client to be
          * configured by the patch, i.e. assigning an Output (HW or SW)
-         * @param[in] forceSwBridge [optional] force the creation of a SW bridge (internal use only)
          * @return NO_ERROR if patch installed correctly, error code otherwise.
          */
         status_t createAudioPatchInternal(const struct audio_patch *patch,
                                           audio_patch_handle_t *handle,
                                           uid_t uid, uint32_t delayMs = 0,
-                                          const sp<SourceClientDescriptor>& sourceDesc = nullptr,
-                                          bool forceSwBridge = false);
+                                          const sp<SourceClientDescriptor>& sourceDesc = nullptr);
         /**
          * @brief releaseAudioPatchInternal internal function to remove an audio patch
          * @param[in] handle of the patch to be removed


### PR DESCRIPTION
* On some MT6771 Q vendor devices, in-call audio is broken due to APM
  failing to create an HW audio patch for RX / TX devices.

> 03-28 11:56:42.300  1345  1345 W DeviceHAL: Error from HAL Device in
function create_audio_patch: Function not implemented
> 03-28 11:56:42.301  1358  1374 W APM_AudioPolicyManager:
createAudioPatchInternal patch panel could not connect device patch,
error -38
> 03-28 11:56:42.301  1358  1374 W APM_AudioPolicyManager:
createTelephonyPatch() error -38 creating RX audio patch

* Our previous attempt at fixing this by falling back to SW bridging was
  wrong, because SW bridging requires a corresponding audio policy
  configuration that includes said SW bridges, which is not the case on
  these devices.

* The sole reason why this was broken at all is that the new R behavior
  tries to use the newer `createAudioPatch` interface of the audio HAL,
  which is broken on these devices for telephony inputs and outputs,
  even though the HAL claims to support it.

* Let's fall back to pre-R behavior (i.e. using the legacy
  setOutputDevices() interface) whenever the new method fails. The
  legacy method takes care of TX (Mic input) as well, so we don't need
  to create the TX patch either.